### PR TITLE
completed lecture 17

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,16 @@
-import Day from './component/Day';
-import DayList from './component/DayList';
-import Header from './component/Header';
-import EmptyPage from './component/EmptyPage';
+import Day from './component/Day.tsx';
+import DayList from './component/DayList.tsx';
+import Header from './component/Header.tsx';
+import EmptyPage from './component/EmptyPage.tsx';
 import {BrowserRouter, Routes, Route} from 'react-router-dom';
-import CreateWord from './component/CreateWord';
-import CreateDay from './component/CreateDay';
+import CreateWord from './component/CreateWord.tsx';
+import CreateDay from './component/CreateDay.tsx';
 
-// git add . 으로 수정 사항 반영
-// git commit -m "completed lecture 10"
-// git push origin 1-complete-lecture-10 => 원격 레포에 올려라
+// json-server --watch ./src/DB/data.json --port 3001
+
+// git add .
+// git commit -m "completed lecture ??"
+// git push origin ?? => 원격 레포에 올려라
 // pull request는 위의 브랜치를 main에 합병을 시켜줌 => 이거까지 하면 끝
 
 function App() {

--- a/src/DB/data.json
+++ b/src/DB/data.json
@@ -15,6 +15,10 @@
     {
       "id": "25a3",
       "day": 4
+    },
+    {
+      "id": "ac5c",
+      "day": 5
     }
   ],
   "words": [
@@ -51,7 +55,7 @@
       "day": "1",
       "eng": "book",
       "kor": "책",
-      "isDone": false
+      "isDone": true
     },
     {
       "id": "e115",
@@ -93,6 +97,20 @@
       "day": "3",
       "eng": "night",
       "kor": "밤",
+      "isDone": false
+    },
+    {
+      "id": "0f4b",
+      "day": "5",
+      "eng": "culture",
+      "kor": "문화",
+      "isDone": false
+    },
+    {
+      "id": "c686",
+      "day": "5",
+      "eng": "table",
+      "kor": "탁자",
       "isDone": false
     }
   ]

--- a/src/component/CreateDay.tsx
+++ b/src/component/CreateDay.tsx
@@ -1,11 +1,13 @@
-import useFetch from "../hooks/useFetch";
+import useFetch from "../hooks/useFetch.ts";
 import { useNavigate } from "react-router-dom";
+import { IDay } from "./DayList";
+import React from "react";
 
 let CreateWord = () => {
-    const days = useFetch(`http://localhost:3001/days`);
+    const days: IDay[] = useFetch(`http://localhost:3001/days`);
     const history = useNavigate();
 
-    let addDay = (e) => {
+    let addDay = (e: React.MouseEvent) => {
         e.preventDefault(); // 기본 기능(새로고침)을 방지
         
         fetch(`http://localhost:3001/days/`, {

--- a/src/component/CreateWord.tsx
+++ b/src/component/CreateWord.tsx
@@ -1,33 +1,41 @@
-import { useRef, useState } from "react";
+import { FormEvent, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import useFetch from "../hooks/useFetch";
+import useFetch from "../hooks/useFetch.ts";
+import React from "react";
+import { IDay } from "./DayList";
 
 let CreateWord = () => {
-    const days = useFetch(`http://localhost:3001/days`);
+    const days : IDay[] = useFetch(`http://localhost:3001/days`);
     const history = useNavigate();
     const [isLoading, setIsLoading] = useState(false);
 
-    let onSubmit = (e) => {
+    let onSubmit = (e: FormEvent) => {
         e.preventDefault(); // 기본 기능(새로고침)을 방지
         
-        if(!isLoading) { 
+        // null이 아님을 체크하고 시작
+        if(!isLoading && dayRef.current && engRef.current && korRef.current) { 
             setIsLoading(true)
+
+            const day = dayRef.current.value;
+            const eng = engRef.current.value;
+            const kor = korRef.current.value;
+
             fetch(`http://localhost:3001/words/`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
-                    day: dayRef.current.value,
-                    eng: engRef.current.value,
-                    kor: korRef.current.value,
+                    day,
+                    eng,
+                    kor,
                     isDone: false,
                 }),
             })
             .then(res => {
                 if(res.ok) {
                     alert('생성이 완료되었습니다.');
-                    history(`/day/${dayRef.current.value}`);
+                    history(`/day/${day}`);
                     setIsLoading(false);
                 }
             });
@@ -35,9 +43,11 @@ let CreateWord = () => {
     }
 
 
-    const engRef = useRef(null);
-    const korRef = useRef(null);
-    const dayRef = useRef(null);
+    // ref로 <?>를 가져올 건데 이때 null일 가능성이 있음
+    // type을 지정 -> engRef에 대한 파악 없이 어떤 기능 쓸 수 있는지 알 수 있음
+    const engRef = useRef<HTMLInputElement>(null);
+    const korRef = useRef<HTMLInputElement>(null);
+    const dayRef = useRef<HTMLSelectElement>(null);
 
     return (
         <>

--- a/src/component/Day.tsx
+++ b/src/component/Day.tsx
@@ -1,12 +1,15 @@
 import { useParams } from "react-router-dom";
 // import EmptyPage from "./EmptyPage";
-import Word from "./Word";
-import useFetch from "../hooks/useFetch";
+import Word from "./Word.tsx";
+import useFetch from "../hooks/useFetch.ts";
+import { IWord } from "./Word.tsx";
+import React from "react";
 
 export default function Day() {
-  const {day} = useParams();
+  // const {day} = useParams(); -> day를 가지는 객체인지 확신할 수 없음
+  const {day} = useParams<{day: string}>(); // 제너릭으로 
 
-  const WordList = useFetch(`http://localhost:3001/words?day=${day}`);
+  const WordList: IWord[] = useFetch(`http://localhost:3001/words?day=${day}`);
   // const Days = useFetch(`http://localhost:3001/days`);
   
   // let a = [];

--- a/src/component/DayList.tsx
+++ b/src/component/DayList.tsx
@@ -1,9 +1,15 @@
 import { Link } from "react-router-dom";
-import useFetch from "../hooks/useFetch";
+import useFetch from "../hooks/useFetch.ts";
+import React from "react";
+
+export interface IDay {
+  day: number,
+  id: number,
+}
 
 export default function DayList() {
   // 우선은 days에 빈 배열
-  const days = useFetch('http://localhost:3001/days'); 
+  const days : IDay[] = useFetch('http://localhost:3001/days'); 
   return (
     <>
     {days.length === 0 && <span>Loading...</span>}

--- a/src/component/EmptyPage.tsx
+++ b/src/component/EmptyPage.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import React from "react";
 
 export default function EmptyPage() {
     return(

--- a/src/component/Header.tsx
+++ b/src/component/Header.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import React from "react";
 
 export default function Header() {
     return (

--- a/src/component/Word.tsx
+++ b/src/component/Word.tsx
@@ -1,9 +1,22 @@
 import { useState } from "react";
+import React from "react";
 
-export default function Word(props) {
-    const [word, setWord] = useState(props.word);
+export interface IProps {
+    word: IWord; // word를 가진 prop를 IProps로
+}
+
+export interface IWord {
+    day: string;
+    eng: string;
+    kor: string;
+    isDone: boolean;
+    id: number;
+}
+
+export default function Word(props: IProps) {
+    const [word, setWord] = useState(props.word); // word는 IProps에서 IWord로 타입 지정 됨
     const [isShow, setIsShow] = useState(false);
-    const [isDone, setIsDone] = useState(word.isDone);
+    const [isDone, setIsDone] = useState(word.isDone); // isDone은 IWord에서 boolean으로 타입 지정 됨
 
     function toggleShow() {
         setIsShow(!isShow);
@@ -35,7 +48,10 @@ export default function Word(props) {
             })
             .then(res => {
                 if(res.ok) {
-                    setWord({id: 0})
+                    setWord({
+                        ...word, // Word를 {id: 0}으로 set하려면 word의 타입에 맞지 않으므로 기존에 있던 property를 가져와 줌
+                        id: 0,
+                    })
                 }
             });
         }

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 
-let useFetch = (url) => {
+let useFetch = (url: string) => {
     const [data, setData] = useState([]);
 
     // useEffect(함수, [])를 통해 렌더링 직후에 한 번 API 호출을 실행


### PR DESCRIPTION
js 파일 중 jsx 반환 시 tsx, 아닐 시 ts로 바꿔주는 작업
- 각 tsx/ts 파일에서 type 지정해줄 부분들 지정
- export/import interface, 제너릭 등을 이용
- 이벤트의 경우 각각 어떤 타입인지 써치해보면 됨

궁금점
- CreateWord에서 dayRef.current가 null인지 확인해주는데, 왜 js에서는 문제가 없는데 tsx에선 생기는지?
- useRef<HTMLInputElement>(null);와 같은 경우 js에서는 type이 없으니 useRef만 쓰이지만, ts에서는 type이 지정되어야 하니 useRef<T> 꼴로 함수가 지정되어 있는 것인가?
- import React from "react"; 하지 않으면 return 부분에서 오류 발생. 이유가 뭔지
Err: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.